### PR TITLE
Implement route protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
         "cookie": "^1.0.2",
+        "jose": "^6.0.11",
         "jsonwebtoken": "^9.0.2",
         "next": "15.3.2",
         "postcss": "^8.5.3",
@@ -7413,6 +7414,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+      "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^3.0.2",
     "cookie": "^1.0.2",
+    "jose": "^6.0.11",
     "jsonwebtoken": "^9.0.2",
     "next": "15.3.2",
     "postcss": "^8.5.3",

--- a/src/lib/auth/edgeTokens.ts
+++ b/src/lib/auth/edgeTokens.ts
@@ -1,0 +1,35 @@
+import { jwtVerify } from "jose";
+
+if (!process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET is not defined in environment variables");
+}
+
+const JWT_SECRET = new TextEncoder().encode(process.env.JWT_SECRET);
+
+export async function verifyAccessTokenEdge(token: string) {
+  try {
+    const { payload } = await jwtVerify(token, JWT_SECRET);
+
+    if (!payload.userId || !payload.email) {
+      throw new Error("Invalid access token structure");
+    }
+
+    return payload as { userId: string; email: string };
+  } catch {
+    throw new Error("Invalid access token");
+  }
+}
+
+export async function verifyRefreshTokenEdge(token: string) {
+  try {
+    const { payload } = await jwtVerify(token, JWT_SECRET);
+
+    if (!payload.userId) {
+      throw new Error("Invalid refresh token structure");
+    }
+
+    return payload as { userId: string };
+  } catch {
+    throw new Error("Invalid refresh token");
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import {
+  verifyAccessTokenEdge,
+  verifyRefreshTokenEdge
+} from "@/lib/auth/edgeTokens";
+import api from "@/lib/api/axiosInstance";
+
+const publicRoutes = ["/auth"];
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (publicRoutes.some((route) => pathname.includes(route))) {
+    return NextResponse.next();
+  }
+
+  const accessToken = request.cookies.get("accessToken")?.value;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
+
+  if (!accessToken && !refreshToken) {
+    return redirectToLogin(request);
+  }
+
+  if (accessToken) {
+    try {
+      await verifyAccessTokenEdge(accessToken);
+      return NextResponse.next();
+    } catch {
+      console.log("Access token invalid, will be refreshing");
+    }
+  }
+
+  if (refreshToken) {
+    try {
+      await verifyRefreshTokenEdge(refreshToken);
+
+      const baseUrl = request.nextUrl.origin;
+      const response = await api.post(`${baseUrl}/api/auth/refresh`, null, {
+        headers: {
+          Cookie: `refreshToken=${refreshToken}`
+        }
+      });
+
+      const newResponse = NextResponse.next();
+      const cookies = response.headers["set-cookie"];
+      if (cookies) {
+        cookies.forEach((cookie) => {
+          newResponse.headers.append("Set-Cookie", cookie);
+        });
+      }
+
+      const newAccessToken = response.headers["set-cookie"]
+        ?.find((cookie) => cookie.startsWith("accessToken="))
+        ?.split(";")[0]
+        .split("=")[1];
+
+      if (!newAccessToken) {
+        throw new Error("No new access token received");
+      }
+
+      await verifyAccessTokenEdge(newAccessToken);
+      return newResponse;
+    } catch {
+      return redirectToLogin(request);
+    }
+  }
+
+  return redirectToLogin(request);
+}
+
+function redirectToLogin(request: NextRequest) {
+  const url = request.nextUrl.clone();
+  url.pathname = "/auth/login";
+  if (
+    !url.pathname.includes("/auth/") &&
+    !request.nextUrl.pathname.includes("/auth/")
+  ) {
+    url.searchParams.set("from", request.nextUrl.pathname);
+  }
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: [
+    // Match all paths except:
+    // - /api/* (handled by axios instance)
+    // - _next/static (static files)
+    // - _next/image (image optimization files)
+    // - favicon.ico (favicon file)
+    // - public folder
+    "/((?!api|_next/static|_next/image|favicon.ico|public/).*)"
+  ]
+};


### PR DESCRIPTION
Add authentication middleware for route protection
- Implements middleware to protect all routes except public ones (e.g., /auth), and /api, as they are handled by the axios instance.
- Verifies access and refresh tokens on each request using edge token verification functions.
- Automatically refreshes access tokens if expired using refresh tokens.
- Redirects unauthenticated users to the login page with a from query parameter to preserve the original destination.
- Excludes API routes, Next.js static assets, images, favicon, and public folder from middleware interception.

This improves app security by enforcing token validation and seamless token refresh on protected routes.

Closes #4 